### PR TITLE
just replace the scratch name with branches

### DIFF
--- a/src/lib/fonts.js
+++ b/src/lib/fonts.js
@@ -12,7 +12,7 @@ const Fonts = {
     ARCADE: 'Arcade',
     ARCHIVO: 'Archivo',
     ARCHIVOBLACK: 'Archivo Black',
-    SCRATCH: 'Scratch',
+    SCRATCH: 'Branches',
     CHINESE: '"Microsoft YaHei", "微软雅黑", STXihei, "华文细黑"',
     JAPANESE: '"ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, "メイリオ", Meiryo, "ＭＳ Ｐゴシック", "MS PGothic"',
     KOREAN: 'Malgun Gothic'


### PR DESCRIPTION
### Resolves

![image](https://github.com/user-attachments/assets/7f69ddae-2495-41ad-bc98-b5be4f2868e6)
^ fixes branches staying scratch

### Proposed Changes

it chages one line bro it just makes branches actually branches lmao

### Reason for Changes

it was still called scratch in the font adding so i changed it

### Test Coverage

its changing the text... no test is really needed